### PR TITLE
部分cdn资源引用改为https方式

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "hexo": {
-    "version": "3.2.0"
+    "version": "3.2.2"
   },
   "dependencies": {
     "hexo": "^3.2.0",

--- a/themes/huxblog/layout/_partial/footer.ejs
+++ b/themes/huxblog/layout/_partial/footer.ejs
@@ -156,7 +156,7 @@
 
 <!--fastClick.js -->
 <script>
-    async("http://cdn.bootcss.com/fastclick/1.0.6/fastclick.min.js", function(){
+    async("https://cdn.bootcss.com/fastclick/1.0.6/fastclick.min.js", function(){
         var $nav = document.querySelector("nav");
         if($nav) FastClick.attach($nav);
     })

--- a/themes/huxblog/layout/_partial/head.ejs
+++ b/themes/huxblog/layout/_partial/head.ejs
@@ -27,9 +27,9 @@
     <%- css('css/highlight') %>
 
     <!-- Custom Fonts -->
-    <!-- <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css"> -->
+    <!-- <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css"> -->
     <!-- Hux change font-awesome CDN to qiniu -->
-    <link href="http://cdn.staticfile.org/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <link href="https://cdn.staticfile.org/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
 
 
     <!-- Hux Delete, sad but pending in China

--- a/themes/huxblog/layout/keynote.ejs
+++ b/themes/huxblog/layout/keynote.ejs
@@ -207,7 +207,7 @@ layout: layout
 </script>
 <!-- anchor-js, Doc:http://bryanbraun.github.io/anchorjs/ -->
 <script>
-    async("http://cdn.bootcss.com/anchor-js/1.1.1/anchor.min.js",function(){
+    async("https://cdn.bootcss.com/anchor-js/1.1.1/anchor.min.js",function(){
         anchors.options = {
           visible: 'always',
           placement: 'right',

--- a/themes/huxblog/layout/post.ejs
+++ b/themes/huxblog/layout/post.ejs
@@ -214,7 +214,7 @@ layout: layout
 </script>
 <!-- anchor-js, Doc:http://bryanbraun.github.io/anchorjs/ -->
 <script>
-    async("http://cdn.bootcss.com/anchor-js/1.1.1/anchor.min.js",function(){
+    async("https://cdn.bootcss.com/anchor-js/1.1.1/anchor.min.js",function(){
         anchors.options = {
           visible: 'always',
           placement: 'right',


### PR DESCRIPTION
如果自己的博客服务器是https协议的话，通过访问http协议访问cdn资源会被拒绝。我全局查看了这个项目引用的资源来自： 

    cdn.bootcss.com
    maxcdn.bootstrapcdn.com
    cdn.staticfile.org
经验证这几个服务器都支持https协议。
